### PR TITLE
feat: add option to toggle Discord mentions

### DIFF
--- a/src/main/kotlin/net/rk4z/fabricord/Fabricord.kt
+++ b/src/main/kotlin/net/rk4z/fabricord/Fabricord.kt
@@ -57,6 +57,7 @@ class Fabricord : DedicatedServerModInitializer {
 		var botActivityMessage: String? = null
 
 		var messageStyle: String? = null
+		var allowMentions: Boolean? = true
 		var webHookId: String? = null
 		//endregion
 	}
@@ -181,6 +182,7 @@ class Fabricord : DedicatedServerModInitializer {
 				botActivityMessage = config.getNullableString("BotActivityMessage")
 
 				messageStyle = config.getNullableString("MessageStyle")
+				allowMentions = config.getNullableBoolean("AllowMentions")
 				webHookId = extractWebhookIdFromUrl(config.getNullableString("WebhookUrl"))
 			}
 		} catch (e: IOException) {

--- a/src/main/kotlin/net/rk4z/fabricord/discord/DiscordBotManager.kt
+++ b/src/main/kotlin/net/rk4z/fabricord/discord/DiscordBotManager.kt
@@ -177,7 +177,13 @@ object DiscordBotManager : ListenerAdapter() {
 
     fun sendToDiscord(message: String) {
         executorService.submit {
-            Fabricord.logChannelID?.let { jda?.getTextChannelById(it)?.sendMessage(message)?.queue() }
+            Fabricord.logChannelID?.let { 
+                val messageAction = jda?.getTextChannelById(it)?.sendMessage(message)
+                if (Fabricord.allowMentions == false) {
+                    messageAction?.setAllowedMentions(emptySet())
+                }
+                messageAction?.queue()
+            }
         }
     }
 }

--- a/src/main/kotlin/net/rk4z/fabricord/discord/DiscordPlayerEventHandler.kt
+++ b/src/main/kotlin/net/rk4z/fabricord/discord/DiscordPlayerEventHandler.kt
@@ -32,9 +32,14 @@ object DiscordPlayerEventHandler {
 
             val data = MessageCreateBuilder()
                 .setContent(message)
-                .build()
+                
 
-            webHookClient!!.sendMessage(data)
+            if (Fabricord.allowMentions == false) {
+                data.setAllowedMentions(emptySet())
+            }
+
+        
+            webHookClient!!.sendMessage(data.build())
                 .setUsername(player.name.string)
                 .setAvatarUrl("https://visage.surgeplay.com/face/256/${player.uuid}")
                 .queue()

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,58 +5,50 @@
 # GitHub -> https://github.com/KT-Ruxy/Fabricord
 # Modrinth -> https://modrinth.com/mod/fabricord
 
-
 # BotToken for use with Discord.
 # To get a BotToken -> https://discord.com/developers/applications
 BotToken: ""
-
 
 # Channel for sending Minecraft logs.
 # If Blank, the mod will not send Minecraft Server General Chat to Discord.
 # To get a Channel ID -> https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID
 LogChannelID: ""
 
-
 # >----- Advanced Settings -----< #
-
 
 # The bot's activity can be changed.
 # "PLAYING", "STREAMING", "LISTENING" and "WATCHING" are available.
 # If blank, "PLAYING" is automatically selected.
 BotActivityStatus: ""
 
-
 # The bot's activity text can be changed.
 # If blank, "Minecraft" is automatically selected.
 BotActivityMessage: ""
-
 
 # The bot's online status can be changed.
 # "ONLINE", "IDLE" and "DO_NOT_DISTURB" are available.
 # If blank, "ONLINE" is automatically selected.
 BotOnlineStatus: ""
 
-
 # The Log Style can be changed.
 # "Classic", "modern" are available.
 # If blank, "classic" is automatically selected.
 MessageStyle: ""
 
-
 # If Message_Style is "modern", you need to set the Webhook URL.
 # To get a Webhook URL -> https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks
 WebhookUrl: ""
 
+# Whether to allow pings like @everyone to be sent from Minecraft to Discord.
+AllowMentions: false
 
 # The message that appears when the server starts.
 # If blank, the message will use the default message.
 ServerStartMessage: ""
 
-
 # The message that appears when the server stops.
 # If blank, the message will use the default message.
 ServerStopMessage: ""
-
 
 # The message that appears when a player joins the server.
 # You can use the "% player%" placeholder.
@@ -64,12 +56,9 @@ ServerStopMessage: ""
 # If blank, the message will use the default message.
 PlayerJoinMessage: ""
 
-
 # The message that appears when a player leaves the server.
 # You can use the "% player%" placeholder.
 # It will be replaced with the player's name.
 # If blank, the message will use the default message.
 PlayerLeaveMessage: ""
-
-
 # >-----------------------------< #


### PR DESCRIPTION
Added a config option that lets the server admin disable mentions, such as @everyone being registered in Discord. Useful for bigger servers